### PR TITLE
Fixed documentation in adafruit_PCT2075.py

### DIFF
--- a/adafruit_pct2075.py
+++ b/adafruit_pct2075.py
@@ -84,7 +84,7 @@ class FaultCount:
 
 class PCT2075:
     """Driver for the PCT2075 Digital Temperature Sensor and Thermal Watchdog.
-        :param ~busio.I2C i2c_bus: The I2C bus the INA260 is connected to.
+        :param ~busio.I2C i2c_bus: The I2C bus the PCT2075 is connected to.
         :param address: The I2C device address for the sensor. Default is ``0x37``.
     """
 


### PR DESCRIPTION
There was a reference to a chip that didn't make sense in the comments.  I assumed the PCT2075 library was copied from the INA260 library, and this was missed.  